### PR TITLE
Enhance shift management UI and workflow

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,23 +1,24 @@
 import GuardForm from "@/components/GuardForm";
-import ShiftForm from "@/components/ShiftForm";
+import ShiftManagement from "@/components/ShiftManagement";
 
 export default function DashboardPage() {
-    return (
-        <main className="p-8 space-y-10">
-            <h1 className="text-3xl font-bold mb-6"> Guards and Shifts Manegmant</h1>
+  return (
+    <main className="space-y-10 p-8">
+      <h1 className="mb-6 text-3xl font-bold">Guards and Shifts Management</h1>
 
-            {/* Guards */}
-            <section className="border p-4 rounded-lg shadow-md">
-                <h2 className="text-xl font-semibold mb-4 text-blue-600"> Add Guard!</h2>
-                <GuardForm />
-                
-              </section>
+      <section className="rounded-lg border p-4 shadow-md">
+        <h2 className="mb-4 text-xl font-semibold text-blue-600">
+          Add Guard
+        </h2>
+        <GuardForm />
+      </section>
 
-              {/* Shifts */}
-              <section className="border p-4 rounded-lg shadow-md">
-                <h2 className="text-xl font-semibold mb-4 text-blue-600"> Add Shift!</h2>
-                <ShiftForm />
-              </section>
-        </main>
-    );
+      <section className="rounded-lg border p-4 shadow-md">
+        <h2 className="mb-4 text-xl font-semibold text-blue-600">
+          Manage Shifts
+        </h2>
+        <ShiftManagement />
+      </section>
+    </main>
+  );
 }

--- a/app/shifts/page.tsx
+++ b/app/shifts/page.tsx
@@ -1,10 +1,10 @@
-import ShiftForm from "@/components/ShiftForm";
+import ShiftManagement from "@/components/ShiftManagement";
 
 export default function ShiftsPage() {
-    return (
-        <main className="p-8">
-            <h1 className="text-2xl font-bold mb-4">Shifts Management</h1>
-            <ShiftForm />
-        </main>
-    )
+  return (
+    <main className="p-8">
+      <h1 className="mb-4 text-2xl font-bold">Shifts Management</h1>
+      <ShiftManagement />
+    </main>
+  );
 }

--- a/components/ShiftForm.tsx
+++ b/components/ShiftForm.tsx
@@ -1,78 +1,158 @@
 "use client";
-import { Guard } from "@prisma/client";
-import { useEffect, useState } from "react";
 
-export default function ShiftForm() {
-    const [guards, setGuards] = useState<Guard[]>([]);
-    const [guardId, setGuardId] = useState<number | null>(null);
-    const [type, setType] = useState("day");
-    const [date, setDate] = useState("");
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { Guard } from "@prisma/client";
 
-    async function loadGuards() {
-        const res = await fetch ("/api/guards");
-        const data = await res.json();
-        setGuards(data);
+interface ShiftFormProps {
+  onShiftCreated?: () => void;
+}
+
+type Feedback = {
+  status: "success" | "error";
+  message: string;
+};
+
+export default function ShiftForm({ onShiftCreated }: ShiftFormProps) {
+  const [guards, setGuards] = useState<Guard[]>([]);
+  const [guardId, setGuardId] = useState<number | null>(null);
+  const [type, setType] = useState<"day" | "night">("day");
+  const [date, setDate] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+
+  const shiftTimes = useMemo(
+    () =>
+      type === "day"
+        ? { startTime: "06:00", endTime: "18:00" }
+        : { startTime: "18:00", endTime: "06:00" },
+    [type]
+  );
+
+  const loadGuards = useCallback(async () => {
+    try {
+      const res = await fetch("/api/guards");
+      if (!res.ok) {
+        throw new Error("Failed to load guards");
+      }
+      const data: Guard[] = await res.json();
+      setGuards(data);
+    } catch (error) {
+      console.error(error);
+      setFeedback({
+        status: "error",
+        message: "Unable to load guards. Please refresh the page.",
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    loadGuards();
+  }, [loadGuards]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setFeedback(null);
+
+    if (guardId == null) {
+      setFeedback({ status: "error", message: "Please select a guard." });
+      return;
+    }
+    if (!date) {
+      setFeedback({ status: "error", message: "Please choose a date." });
+      return;
     }
 
-    async function handleSubmit(e: React.FormEvent) {
-        e.preventDefault();
-        const res = await fetch("/api/shifts", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-                type, 
-                startTime: type === "day" ? "06:00" : "18:00",
-                endTime: type === "night" ? "18:00" : "06:00", 
-                date,
-                guardId,
-            }),
-        });
-        if (res.ok) alert("Shift added successfully!");
+    setIsSubmitting(true);
+    try {
+      const res = await fetch("/api/shifts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type,
+          ...shiftTimes,
+          date,
+          guardId,
+        }),
+      });
+
+      if (!res.ok) {
+        throw new Error("Failed to create shift");
+      }
+
+      setFeedback({
+        status: "success",
+        message: "Shift added successfully!",
+      });
+      setGuardId(null);
+      setType("day");
+      setDate("");
+      onShiftCreated?.();
+    } catch (error) {
+      console.error(error);
+      setFeedback({
+        status: "error",
+        message: "Unable to save the shift. Please try again.",
+      });
+    } finally {
+      setIsSubmitting(false);
     }
+  };
 
-    useEffect(() => {
-        loadGuards();
-    }, []);
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-col gap-3 rounded-md border p-4"
+    >
+      <h2 className="text-xl font-bold">Add Shift</h2>
 
-    return (
-        <form onSubmit={handleSubmit} className="flex flex-col gap-3 border p-4 rounded-md mt-4">
-            <h2 className="text-x1 font-bold">Add Shift</h2>
+      <select
+        className="rounded border p-2"
+        value={guardId ?? ""}
+        onChange={(e) =>
+          setGuardId(e.target.value ? Number(e.target.value) : null)
+        }
+      >
+        <option value="">Select Guard</option>
+        {guards.map((g) => (
+          <option key={g.id} value={g.id}>
+            {g.name}
+          </option>
+        ))}
+      </select>
 
-            <select 
-            className="border p-2 rounded"
-            value={guardId ?? ""}
-            onChange={(e) => setGuardId(Number(e.target.value))}
-            >
-                <option value="">Select Guard</option>
-                {guards.map((g) => (
-                    <option key={g.id} value={g.id}>
-                        {g.name}
-                    </option>
-                ))}
-            </select>
+      <select
+        className="rounded border p-2"
+        value={type}
+        onChange={(e) => setType(e.target.value as "day" | "night")}
+      >
+        <option value="day">Day Shift (06:00 - 18:00)</option>
+        <option value="night">Night Shift (18:00 - 06:00)</option>
+      </select>
 
-            <select
-            className="border p-2 rounded"
-            value={type}
-            onChange={(e) => setType(e.target.value)}
-            >
-                <option value="day">Day Shift (06:00 - 18:00)</option>
-                <option value="night">Night Shift (18:00 - 06:00)</option>
+      <input
+        type="date"
+        className="rounded border p-2"
+        value={date}
+        onChange={(e) => setDate(e.target.value)}
+      />
 
-            </select>
+      <button
+        type="submit"
+        className="rounded bg-green-600 p-2 text-white hover:bg-green-700 disabled:cursor-not-allowed disabled:bg-green-400"
+        disabled={isSubmitting}
+      >
+        {isSubmitting ? "Saving..." : "Add Shift"}
+      </button>
 
-            <input
-            type="date"
-            className="border p-2 rounded"
-            value={date}
-            onChange={(e) => setDate(e.target.value)}
-            />
-
-            <button type="submit" className="bg-green-600 text-white p-2 rounded hover:bg-green-700">
-                Add Shift
-            </button>
-
-        </form>
-    );
-
+      {feedback && (
+        <p
+          className={`text-sm ${
+            feedback.status === "success" ? "text-green-600" : "text-red-600"
+          }`}
+        >
+          {feedback.message}
+        </p>
+      )}
+    </form>
+  );
 }

--- a/components/ShiftList.tsx
+++ b/components/ShiftList.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { Guard } from "@prisma/client";
+
+interface ShiftListProps {
+  refreshKey?: number;
+}
+
+type ShiftResponse = {
+  id: number;
+  type: string;
+  startTime: string;
+  endTime: string;
+  date: string;
+  guard?: Guard | null;
+};
+
+export default function ShiftList({ refreshKey = 0 }: ShiftListProps) {
+  const [shifts, setShifts] = useState<ShiftResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadShifts() {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const res = await fetch("/api/shifts");
+        if (!res.ok) {
+          throw new Error("Failed to load shifts");
+        }
+        const data: ShiftResponse[] = await res.json();
+        if (isMounted) {
+          setShifts(data);
+        }
+      } catch (err) {
+        console.error(err);
+        if (isMounted) {
+          setError("Unable to load shifts. Please try again.");
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    loadShifts();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [refreshKey]);
+
+  const formatDate = (value: string) => {
+    const date = new Date(value);
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: "medium",
+    }).format(date);
+  };
+
+  if (loading) {
+    return <p className="text-sm text-gray-500">Loading shifts…</p>;
+  }
+
+  if (error) {
+    return <p className="text-sm text-red-600">{error}</p>;
+  }
+
+  if (shifts.length === 0) {
+    return <p className="text-sm text-gray-500">No shifts scheduled yet.</p>;
+  }
+
+  return (
+    <ul className="space-y-3">
+      {shifts.map((shift) => (
+        <li
+          key={shift.id}
+          className="flex flex-col gap-2 rounded-md border p-3 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <div>
+            <p className="font-semibold">
+              {shift.guard?.name ?? "Unassigned guard"}
+            </p>
+            <p className="text-sm text-gray-500">
+              {formatDate(shift.date)} · {shift.type === "day" ? "Day" : "Night"} shift
+            </p>
+          </div>
+          <div className="text-sm font-medium text-gray-700">
+            {shift.startTime} → {shift.endTime}
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/components/ShiftManagement.tsx
+++ b/components/ShiftManagement.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useState } from "react";
+
+import ShiftForm from "./ShiftForm";
+import ShiftList from "./ShiftList";
+
+export default function ShiftManagement() {
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  return (
+    <div className="space-y-6">
+      <ShiftForm onShiftCreated={() => setRefreshKey((key) => key + 1)} />
+      <div>
+        <h3 className="text-lg font-semibold">Scheduled shifts</h3>
+        <ShiftList refreshKey={refreshKey} />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- improve the shift creation form with validation, success/error feedback, and corrected time ranges
- add reusable components to display scheduled shifts and refresh the list after creating a new entry
- update the dashboard and shifts pages to embed the combined shift management panel

## Testing
- npm run lint *(fails: script not defined in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68e68bdaf35083238956b6b378f5683b