### PR TITLE
Add environment template and deployment documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Application
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_SECRET=replace-with-generated-secret
+
+# OAuth Providers
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+GITHUB_CLIENT_ID=your-github-client-id
+GITHUB_CLIENT_SECRET=your-github-client-secret
+
+# Database
+# Use the pooled connection string for your application (Render external connection string with connection pooling).
+DATABASE_URL=postgresql://momo:secret@localhost:5433/freiewuensche?schema=public
+# Use a non-pooled connection string for migrations (Render external connection string without pooling).
+DIRECT_DATABASE_URL=postgresql://momo:secret@localhost:5433/freiewuensche?schema=public

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -1,36 +1,88 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# yourShift
 
-## Getting Started
+A Next.js application for managing guard shifts powered by Prisma and NextAuth.
 
-First, run the development server:
+## Prerequisites
+
+- Node.js 18+
+- npm (bundled with Node.js)
+- PostgreSQL 15+ (local or managed, e.g. Render)
+
+## Environment variables
+
+Copy the template and adjust values for your environment:
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+cp .env.example .env.local
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+| Variable | Required | Description |
+| --- | --- | --- |
+| `NEXTAUTH_URL` | ✔ | Base URL of the application (set to the deployed domain in production). |
+| `NEXTAUTH_SECRET` | ✔ | Secret used by NextAuth to encrypt tokens. Generate with `openssl rand -hex 32`. |
+| `GOOGLE_CLIENT_ID` | ✔ | Google OAuth client ID. |
+| `GOOGLE_CLIENT_SECRET` | ✔ | Google OAuth client secret. |
+| `GITHUB_CLIENT_ID` | ✔ | GitHub OAuth client ID. |
+| `GITHUB_CLIENT_SECRET` | ✔ | GitHub OAuth client secret. |
+| `DATABASE_URL` | ✔ | Pooled PostgreSQL connection string used by the app (e.g. Render connection string via connection pooling). |
+| `DIRECT_DATABASE_URL` | ✔ | Direct PostgreSQL connection string used for Prisma migrations. |
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Local development
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+1. Start PostgreSQL locally or with Docker:
+   ```bash
+   docker compose up -d postgres
+   ```
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Push the database schema:
+   ```bash
+   npx prisma db push
+   ```
+4. Start the dev server:
+   ```bash
+   npm run dev
+   ```
+5. Open [http://localhost:3000](http://localhost:3000) in your browser.
 
-## Learn More
+## Deployment
 
-To learn more about Next.js, take a look at the following resources:
+### 1. Provision PostgreSQL on Render
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+1. Create a **Render PostgreSQL** instance.
+2. Enable the [built-in connection pooler](https://docs.render.com/databases#connection-pooling).
+3. Copy two connection strings:
+   - **Pooled connection string** → `DATABASE_URL`
+   - **Direct connection string** → `DIRECT_DATABASE_URL`
+4. Ensure both strings include `?sslmode=require` for secure connections.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+### 2. Configure Vercel project
 
-## Deploy on Vercel
+1. Create a new Vercel project and import this repository.
+2. In **Settings → Environment Variables**, add the variables from `.env.example` using the Render values for `DATABASE_URL`/`DIRECT_DATABASE_URL` and production OAuth credentials.
+3. Set `NEXTAUTH_URL` to the production domain (e.g. `https://yourshift.vercel.app`).
+4. Trigger the first deployment; Vercel will build the Next.js app.
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+### 3. Run Prisma migrations in production
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+On Vercel, migrations should be run via a one-off command:
+
+```bash
+vercel env pull .env.production
+npx prisma migrate deploy --schema=prisma/schema.prisma
+```
+
+Alternatively, run `npx prisma migrate deploy` inside a Vercel deployment hook or CI pipeline with the production environment variables loaded.
+
+Once migrations are applied, the application will connect to Render's PostgreSQL using the pooled URL while Prisma uses the direct URL for schema changes.
+
+## Useful commands
+
+```bash
+npm run dev       # Start development server
+npm run build     # Create production build
+npm run start     # Run production build locally
+npx prisma studio # Open Prisma Studio to inspect data
+```

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,6 +5,7 @@ generator client {
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
+  directUrl = env("DIRECT_DATABASE_URL")
 }
 
 model Guard {


### PR DESCRIPTION
## Summary
- add an `.env.example` covering NextAuth, OAuth providers, and PostgreSQL connection strings
- configure Prisma to read a dedicated direct database URL for running migrations in production
- document Render database provisioning, Vercel setup, and local workflow updates in the README while allowing the env template to be tracked

## Testing
- `DIRECT_DATABASE_URL=postgresql://localhost:5432/postgres DATABASE_URL=postgresql://localhost:5432/postgres npx prisma validate`


------
https://chatgpt.com/codex/tasks/task_e_68f23899fec08323b3f4841f0f2b7c8c